### PR TITLE
Update wording and restrict UW widget to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Setup
 
+Create an unsigned upload preset in your Cloudinary product environment.
+
 Create a `.env` file with the following content:
 
 ```
 VITE_CLOUD_NAME='YOUR-CLOUD-NAME'
-VITE_UPLOAD_PRESET='YOUR-UPLOAD-PRESET'
+VITE_UPLOAD_PRESET='YOUR-UNSIGNED-UPLOAD-PRESET'
 ```
 
 # Run

--- a/src/components/Welcome.jsx
+++ b/src/components/Welcome.jsx
@@ -6,20 +6,20 @@ const Welcome = () => {
         This sample project shows how to use the{' '}
         <a className="underline text-blue-500" href="https://cloudinary.com/documentation/react_integration">
           Cloudinary React SDK
-        </a>
+        </a>.
       </p>
       <div className="p-2">
         The following pieces of functionality are exposed in this app:
         <ul className="list-disc list-inside">
           <li>
-            <a className="underline text-blue-500" href="./upload">Upload (Upload Widget)</a>: shows an example implementation of the <a className="underline text-blue-500" href="https://cloudinary.com/documentation/upload_widget">Upload Widget</a>
+            <a className="underline text-blue-500" href="./upload">Upload (Upload Widget)</a>: shows an example implementation of the <a className="underline text-blue-500" href="https://cloudinary.com/documentation/upload_widget">Upload Widget</a>.
           </li>
           <li>
           <a className="underline text-blue-500" href="./apiupload">API Upload</a>: shows an example of how to use the <a className="underline text-blue-500" href="https://cloudinary.com/documentation/image_upload_api_reference">Upload API</a> to upload
-            from a React context
+            from a React context.
           </li>
           <li>
-          <a className="underline text-blue-500" href="./album">Photo Album</a>: shows how to display images from a Cloudinary account
+          <a className="underline text-blue-500" href="./album">Photo Album</a>: shows how to display images from a Cloudinary product environment.
           </li>
         </ul>
       </div>

--- a/src/routes/Album.jsx
+++ b/src/routes/Album.jsx
@@ -44,7 +44,7 @@ const Album = () => {
             are displayed.
           </li>
           <li>
-            Images are transformed using the following option:{' '}
+            Images are transformed using the following actions:{' '}
             <code className="bg-black text-gray-100 px-2 py-1 rounded-md text-sm whitespace-normal overflow-auto break-words">
               .resize(thumbnail().width(300).height(300).gravity(autoGravity())).delivery(format(&apos;auto&apos;)).delivery(quality(&apos;auto&apos;));
             </code>

--- a/src/routes/ApiUpload.jsx
+++ b/src/routes/ApiUpload.jsx
@@ -10,16 +10,16 @@ const ApiUpload = () => {
       <div className="m-2">
         Please note that the following defaults are being used:
         <ul className="list-disc list-inside">
-          <li>The sample uses the HTML5 Drag & Drop API</li>
+          <li>The sample uses the HTML5 Drag & Drop API.</li>
           <li>
             The{' '}
             <code className="bg-black text-gray-100 px-2 py-1 rounded-md text-sm">
               myphotoalbum-react
             </code>{' '}
             tag gets added to all photos uploaded via this method (this is used
-            in the photo album to retrieve images)
+            in the photo album to retrieve images).
           </li>
-          <li>Only images can be uploaded</li>
+          <li>Only images are displayed in the photo album, even though you can potentially upload other file types here too.</li>
         </ul>
       </div>
       <DragAndDrop />

--- a/src/routes/Upload.jsx
+++ b/src/routes/Upload.jsx
@@ -68,9 +68,9 @@ const Upload = () => {
               myphotoalbum-react
             </code>{' '}
             tag gets added to all photos uploaded via this method (this is used
-            in the photo album to retrieve images)
+            in the photo album to retrieve images).
           </li>
-          <li>Only images can be uploaded</li>
+          <li>Only images can be uploaded.</li>
         </ul>
       </div>
       <button


### PR DESCRIPTION
Updated wording and restricted the UW widget to images.

You should be able to use `allowed_formats` in the drag and drop upload API example to allow only image formats.  I tried briefly but the upload resulted in errors.  If you can get that working, that would be good.